### PR TITLE
Change createAndAttch from arror function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -46,7 +46,7 @@ class MovieContainer {
         this.cleanString = DOMPurify.sanitize(this.htmlString);
         this.location = location;
     }
-    createAndAttch = () => {
+    createAndAttch() {
         this.container.insertAdjacentHTML("beforeend",this.cleanString);
         this.location.appendChild(this.container);
     }


### PR DESCRIPTION
Due to error on build:

> 
> ```
> ERROR in ./src/utils.js
> Module build failed (from ./node_modules/babel-loader/lib/index.js):
> SyntaxError: C:\Users\Greg\Desktop\Code\JSFUN_final_projects\Final_Project_ACC\src\utils.js: Support for the experimental syntax 'classProperties' isn't currently enabled (49:20):
> ```

`MovieContainer `method `createAndAttch `causes an error at build time as an arrow function. Changing to standard function declaration resolves this.